### PR TITLE
added Ids -- do not merge

### DIFF
--- a/input/fsh/bundlescompositions/BundleDocumentBFDRNew.fsh
+++ b/input/fsh/bundlescompositions/BundleDocumentBFDRNew.fsh
@@ -2,6 +2,7 @@ Profile: BundleDocumentBFDR
 Parent: Bundle
 Title: "Bundle - Document Birth and Fetal Death"
 Description: "This Bundle profile represents a Birth and Fetal Death Document Bundle. It contains any one of the Birth and Fetal Death Compositions."
+Id: Bundle-document-bfdr
 * identifier //1.. 
   * ^short = "BFDR Document Bundle identifier"
 * insert BundleIdentifiers

--- a/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeathNew.fsh
+++ b/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeathNew.fsh
@@ -36,6 +36,7 @@ Profile: CompositionCodedCauseOfFetalDeath
 Parent: Composition
 Title: "Composition - Coded Cause of Fetal Death"
 Description: "This profile communicates coded cause of fetal death information to appropriate jurisdictional Vital Records Offices."
+Id: Bundle-coded-cause-of-fetal-death
 * extension 
   * ^slicing.discriminator.type = #value
   * ^slicing.discriminator.path = "url"

--- a/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeathNew.fsh
+++ b/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeathNew.fsh
@@ -36,7 +36,7 @@ Profile: CompositionCodedCauseOfFetalDeath
 Parent: Composition
 Title: "Composition - Coded Cause of Fetal Death"
 Description: "This profile communicates coded cause of fetal death information to appropriate jurisdictional Vital Records Offices."
-Id: Bundle-coded-cause-of-fetal-death
+Id: Composition-coded-cause-of-fetal-death
 * extension 
   * ^slicing.discriminator.type = #value
   * ^slicing.discriminator.path = "url"

--- a/input/fsh/bundlescompositions/CompositionJurisdictionFetalDeathReportNew.fsh
+++ b/input/fsh/bundlescompositions/CompositionJurisdictionFetalDeathReportNew.fsh
@@ -2,6 +2,7 @@ Profile: CompositionJurisdictionFetalDeathReport
 Parent: Composition
 Title: "Composition - Jurisdiction Fetal Death Report"
 Description: "This Composition profile contains information of a fetal death and the creation of a jurisdictional file to be recorded and communicated to the national statistics agency."
+Id: Composition-jurisdiction-fetal-death-report 
 * extension 1.. 
   * ^slicing.discriminator.type = #value
   * ^slicing.discriminator.path = "url"

--- a/input/fsh/bundlescompositions/CompositionJurisdictionLiveBirthReportNew.fsh
+++ b/input/fsh/bundlescompositions/CompositionJurisdictionLiveBirthReportNew.fsh
@@ -2,6 +2,7 @@ Profile: CompositionJurisdictionLiveBirthReport
 Parent: Composition
 Title: "Composition - Jurisdiction Live Birth Report"
 Description: "This Composition profile contains information of a live birth and the issuance of a Birth Certificate to be recorded and communicated to the national statistics agency."
+Id: Composition-jurisdiction-live-birth-report 
 * . ^short = "Jurisdiction Live Birth Report"
 * extension 1.. 
   * ^slicing.discriminator.type = #value

--- a/input/fsh/bundlescompositions/CompositionProviderLiveBirthReportNew.fsh
+++ b/input/fsh/bundlescompositions/CompositionProviderLiveBirthReportNew.fsh
@@ -2,6 +2,7 @@ Profile: CompositionProviderLiveBirthReport
 Parent: Composition
 Title: "Composition - Provider Live Birth Report"
 Description: "This Composition profile defines constraints to address the use case in which information for live birth information is recorded and communicated to the jurisdictional Vital Records Office."
+Id: Composition-provider-live-birth-report 
 * . ^short = "Provider Live Birth Report"
 * extension 
   * ^slicing.discriminator.type = #value


### PR DESCRIPTION
BundleDocumentBFDR
CompositionCodedCauseOfFetalDeath
CompositionJurisdictionFetalDeathReport
CompositionProviderLiveBirthReport

were missing defined IDs, so they had default ID (equal to computable name).

Discovered this trying to fixup JiraSpec file, where it complained that I needed to deprecate the old names.

What else needs to be fixed (data dictionary?   Form Mapping?) to align with the new (actually old) ids for these profiles?