### PR TITLE
adding short desc to code bindings

### DIFF
--- a/input/fsh/profiles/ObservationBirthWeight_new.fsh
+++ b/input/fsh/profiles/ObservationBirthWeight_new.fsh
@@ -5,6 +5,7 @@ Id: Observation-birth-weight
 Title: "Observation - Birth Weight"
 Description: "The weight of the infant/fetus at birth/delivery. Migrated from VRCL."
 * code = $loinc#8339-4
+  * ^short = "Birth weight Measured"
 * category[VSCat] = $observation-category#vital-signs
 * subject 1..
 * subject only Reference(PatientChildVitalRecords or PatientDecedentFetus)
@@ -12,6 +13,7 @@ Description: "The weight of the infant/fetus at birth/delivery. Migrated from VR
 * value[x] only Quantity
 * valueQuantity ^short = "Birth weight in grams"
   * code = $UCUM#g (exactly)
+    * ^short = "grams"
   * value 1..1
 // Add Edit Flags, a la VRDR 
 * value[x].extension contains

--- a/input/fsh/profiles/ObservationCodedInitiatingFetalDeathCauseOrCondition.fsh
+++ b/input/fsh/profiles/ObservationCodedInitiatingFetalDeathCauseOrCondition.fsh
@@ -5,6 +5,7 @@ Title: "Observation - Coded Initiating Fetal Death Cause or Condition"
 Description: "This profile represents the coded initiating cause/condition of fetal death."
 * . ^short = "This profile represents the coded initiating cause/condition of fetal death."
 * code = $loinc#92022-3 "Coded initiating cause or condition of fetal death"
+  * ^short = "Coded initiating cause or condition of fetal death"
 * code 1..1 MS 
 * value[x] 1..1 MS
 * value[x] only CodeableConcept

--- a/input/fsh/profiles/ObservationCodedOtherFetalDeathCauseOrCondition.fsh
+++ b/input/fsh/profiles/ObservationCodedOtherFetalDeathCauseOrCondition.fsh
@@ -4,6 +4,7 @@ Id: Observation-coded-other-fetal-death-cause-or-condition
 Title: "Observation - Coded Other Fetal Death Cause or Condition"
 Description: "This profile represents a coded other significant cause/condition of fetal death."
 * code = $loinc#92023-1 "Coded other significant causes or conditions of fetal death"
+  * ^short = "Coded other significant causes or conditions of fetal death"
 * code 1..1 MS 
 * subject only Reference(PatientDecedentFetus)
 * value[x] 1..1 MS
@@ -20,6 +21,7 @@ Description: "This profile represents a coded other significant cause/condition 
 * component[position].valueInteger ^maxValueInteger = 7
 * component[position].valueInteger ^minValueInteger = 1
 * component[position].code = $sct#246268007 "Position (attribute)"
+  * ^short = "Position (attribute)"
 * component[position] ^short = "Position"
 * component[position].code 1..1
 * component[position].value[x] 1..1

--- a/input/fsh/profiles/ObservationGestationalAgeAtDelivery.fsh
+++ b/input/fsh/profiles/ObservationGestationalAgeAtDelivery.fsh
@@ -7,6 +7,7 @@ Description: "The obstetric estimate of the infant’s gestation in completed we
 determined by all perinatal factors and assessments such as ultrasound, but not the neonatal exam.  For submission to NCHS, values in days will be divided by 7 without remainder, and values
 in weeks will be rounded down to an integer."
 * code = $loinc#11884-4
+  * ^short = "Gestational age Estimated"
 * subject 1..
 * subject only Reference(PatientChildVitalRecords or PatientDecedentFetus)
 * value[x] 1..

--- a/input/fsh/profiles/ObservationMotherDeliveryWeight.fsh
+++ b/input/fsh/profiles/ObservationMotherDeliveryWeight.fsh
@@ -4,17 +4,18 @@ Parent: USCoreVitalSignsProfile
 Id: Observation-mother-delivery-weight
 Title: "Observation - Mother Delivery Weight"
 Description: "The weight of the mother at the time of birth/delivery. Migrated from VRCL."
-* code = $loinc#69461-2
 * subject 1..
 * subject only Reference(PatientMotherVitalRecords)
 * value[x] 1..
 * value[x] only Quantity
 * valueQuantity ^short = "Mother's weight in lb"
   * code = $UCUM#[lb_av] (exactly)
+    * ^short = "pound"
   * value 1..1 
 * category
   * text = "Vital Signs"
 * code = $loinc#69461-2 "Mother's body weight --at delivery"
+  * ^short = "Mother's body weight --at delivery"
 // Add Edit Flags, a la VRDR 
 * value[x].extension contains
     BypassEditFlag named bypassEditFlag 0..1

--- a/input/fsh/profiles/ObservationMotherHeight_new.fsh
+++ b/input/fsh/profiles/ObservationMotherHeight_new.fsh
@@ -12,6 +12,7 @@ Description: "The height of the mother. Migrated from VRCL."
 * value[x] only Quantity
 * valueQuantity ^short = "Height of Mother in inches"
   * code = $UCUM#[in_i] (exactly)
+    * ^short = "inch"
   * value 1..1 
 // Add Edit Flags, a la VRDR 
 * value[x].extension contains

--- a/input/fsh/profiles/ObservationMotherPrepregnancyWeight.fsh
+++ b/input/fsh/profiles/ObservationMotherPrepregnancyWeight.fsh
@@ -12,6 +12,7 @@ Description: "The weight of the mother before becoming pregnant. Migrated from V
 * value[x] only Quantity
 * valueQuantity ^short = "Weight in lb"
   * code = $UCUM#[lb_av] (exactly)
+    * ^short = "pound"
   * value 1..1 
 // Add Edit Flags, a la VRDR 
 * value[x].extension contains


### PR DESCRIPTION
### Summary

adding short desc to code bindings

Question: Should codes within categories also have shorts set? It seems unnecessary, but thought I would check (e.g., [assisted ventilation](http://build.fhir.org/ig/HL7/fhir-bfdr/StructureDefinition-Procedure-assisted-ventilation-following-delivery.html))