### PR TITLE
add name.text to certifier and attendant

### DIFF
--- a/input/fsh/instances/practitioner-vital-records-avery-jones.fsh
+++ b/input/fsh/instances/practitioner-vital-records-avery-jones.fsh
@@ -10,6 +10,7 @@ Usage: #example
   * family = "Jones"
   * given = "Avery"
   * suffix = "D.O."
+  * text = "Avery Jones"
 * qualification.code = $sct#76231001 "Osteopath (occupation)"
 * extension[0]
   * url = "http://hl7.org/fhir/us/bfdr/StructureDefinition/practitioner-role-birth-attendant" 

--- a/input/fsh/instances/practitioner-vital-records-janet-seito.fsh
+++ b/input/fsh/instances/practitioner-vital-records-janet-seito.fsh
@@ -10,6 +10,7 @@ Usage: #example
   * family = "Janet"
   * given = "Seito"
   * suffix = "D.O."
+  * text = "Janet Seito"
 // This seems like a mistake (not by us)
 // * name
 //   * family = "Jones"


### PR DESCRIPTION
Sarah from the software team asked if we could add name.text for the certifier and attendant examples since that's what CERTIF_NAME and ATTEND_NAME are mapped to in the data dictionary
