### PR TITLE
Updated cardinality in CCOD composition

### DIFF
--- a/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeath.fsh
+++ b/input/fsh/bundlescompositions/CompositionCodedCauseOfFetalDeath.fsh
@@ -10,7 +10,6 @@ Id: Composition-coded-cause-of-fetal-death
 * type = $loinc#86804-2
   * ^short = "Cause of death classification and related information Document"
   * ^definition = "Cause of death classification and related information Document"
-* subject 1.. 
 * subject only Reference(PatientDecedentFetus)
 * author ..1 
   * ^short = "The author is the NCHS."

--- a/oids.ini
+++ b/oids.ini
@@ -1,0 +1,171 @@
+[Documentation]
+information1 = This file stores the OID assignments for resources defined in this IG.
+information2 = It must be added to git and committed when resources are added or their id is changed
+information3 = You should not generally need to edit this file, but if you do:
+information4 =  (a) you can change the id of a resource (left side) if you change it's actual id in your source, to maintain OID consistency
+information5 =  (b) you can change the oid of the resource to an OID you assign manually. If you really know what you're doing with OIDs
+information6 = There is never a reason to edit anything else
+
+[Key]
+CodeSystem = 2
+ValueSet = 23
+ConceptMap = 14
+StructureDefinition = 101
+CapabilityStatement = 1
+Questionnaire = 2
+
+[CodeSystem]
+CodeSystem-edit-flags = 2.16.840.1.113883.4.642.40.13.16.1
+CodeSystem-local-bfdr-codes = 2.16.840.1.113883.4.642.40.13.16.2
+
+[ValueSet]
+ValueSet-apgar-timing = 2.16.840.1.113883.4.642.40.13.48.1
+ValueSet-birth-and-fetal-death-financial-class = 2.16.840.1.113883.4.642.40.13.48.2
+ValueSet-birth-attendant-titles = 2.16.840.1.113883.4.642.40.13.48.3
+ValueSet-birth-delivery-occurred = 2.16.840.1.113883.4.642.40.13.48.4
+ValueSet-birth-weight-edit-flags = 2.16.840.1.113883.4.642.40.13.48.5
+ValueSet-delivery-routes = 2.16.840.1.113883.4.642.40.13.48.6
+ValueSet-estimate-of-gestation-edit-flags = 2.16.840.1.113883.4.642.40.13.48.7
+ValueSet-fertility-enhancing-drug-therapy-artificial-insem = 2.16.840.1.113883.4.642.40.13.48.8
+ValueSet-fetal-death-cause-or-condition = 2.16.840.1.113883.4.642.40.13.48.9
+ValueSet-fetal-death-time-points = 2.16.840.1.113883.4.642.40.13.48.10
+ValueSet-fetal-presentations-max = 2.16.840.1.113883.4.642.40.13.48.11
+ValueSet-fetal-presentations = 2.16.840.1.113883.4.642.40.13.48.12
+ValueSet-fetal-remains-disposition-method = 2.16.840.1.113883.4.642.40.13.48.13
+ValueSet-infections-during-pregnancy-live-birth = 2.16.840.1.113883.4.642.40.13.48.14
+ValueSet-informant-relationship-to-mother = 2.16.840.1.113883.4.642.40.13.48.15
+ValueSet-location-types = 2.16.840.1.113883.4.642.40.13.48.16
+ValueSet-newborn-congenital-anomalies = 2.16.840.1.113883.4.642.40.13.48.17
+ValueSet-number-previous-cesareans-edit-flags = 2.16.840.1.113883.4.642.40.13.48.18
+ValueSet-obstetric-procedure-outcome = 2.16.840.1.113883.4.642.40.13.48.19
+ValueSet-performed-not-performed-planned = 2.16.840.1.113883.4.642.40.13.48.20
+ValueSet-pregnancy-report-edit-flags = 2.16.840.1.113883.4.642.40.13.48.21
+ValueSet-units-of-gestational-age = 2.16.840.1.113883.4.642.40.13.48.22
+cigarette-smoking-before-during-pregnancy = 2.16.840.1.113883.4.642.40.13.48.23
+
+[ConceptMap]
+BirthAndFetalDeathFinancialClassCM = 2.16.840.1.113883.4.642.40.13.18.1
+BirthAttendantTitlesCM = 2.16.840.1.113883.4.642.40.13.18.2
+BirthDeliveryOccurredCM = 2.16.840.1.113883.4.642.40.13.18.3
+BirthWeightEditFlagsCM = 2.16.840.1.113883.4.642.40.13.18.4
+DeliveryRoutesCM = 2.16.840.1.113883.4.642.40.13.18.5
+EstimateOfGestationEditFlagsCM = 2.16.840.1.113883.4.642.40.13.18.6
+FetalDeathCauseOrConditionCM = 2.16.840.1.113883.4.642.40.13.18.7
+FetalDeathTimePointsCM = 2.16.840.1.113883.4.642.40.13.18.8
+FetalPresentationCM = 2.16.840.1.113883.4.642.40.13.18.9
+InfectionsDuringPregnancyLiveBirthCM = 2.16.840.1.113883.4.642.40.13.18.10
+NewbornCongenitalAnomaliesCM = 2.16.840.1.113883.4.642.40.13.18.11
+NumberPreviousCesareansEditFlagsCM = 2.16.840.1.113883.4.642.40.13.18.12
+PerformedNotPerformedPlannedCM = 2.16.840.1.113883.4.642.40.13.18.13
+PregnancyReportEditFlagsCM = 2.16.840.1.113883.4.642.40.13.18.14
+
+[StructureDefinition]
+Bundle-document-birth-report = 2.16.840.1.113883.4.642.40.13.42.1
+Bundle-document-coded-cause-of-fetal-death = 2.16.840.1.113883.4.642.40.13.42.2
+Bundle-document-coded-industry-occupation = 2.16.840.1.113883.4.642.40.13.42.3
+Bundle-document-demographic-coded-content = 2.16.840.1.113883.4.642.40.13.42.4
+Bundle-document-fetal-death-report = 2.16.840.1.113883.4.642.40.13.42.5
+Composition-coded-cause-of-fetal-death = 2.16.840.1.113883.4.642.40.13.42.6
+Composition-coded-industry-and-occupation = 2.16.840.1.113883.4.642.40.13.42.7
+Composition-coded-race-and-ethnicity = 2.16.840.1.113883.4.642.40.13.42.8
+Composition-jurisdiction-fetal-death-report = 2.16.840.1.113883.4.642.40.13.42.9
+Composition-jurisdiction-live-birth-report = 2.16.840.1.113883.4.642.40.13.42.10
+Composition-provider-fetal-death-report = 2.16.840.1.113883.4.642.40.13.42.11
+Composition-provider-live-birth-report = 2.16.840.1.113883.4.642.40.13.42.12
+Condition-chorioamnionitis = 2.16.840.1.113883.4.642.40.13.42.13
+Condition-congenital-anomaly-of-newborn = 2.16.840.1.113883.4.642.40.13.42.14
+Condition-eclampsia-hypertension = 2.16.840.1.113883.4.642.40.13.42.15
+Condition-fetal-death-initiating-cause-or-condition = 2.16.840.1.113883.4.642.40.13.42.16
+Condition-fetal-death-other-cause-or-condition = 2.16.840.1.113883.4.642.40.13.42.17
+Condition-gestational-diabetes = 2.16.840.1.113883.4.642.40.13.42.18
+Condition-gestational-hypertension = 2.16.840.1.113883.4.642.40.13.42.19
+Condition-infection-present-during-pregnancy = 2.16.840.1.113883.4.642.40.13.42.20
+Condition-perineal-laceration = 2.16.840.1.113883.4.642.40.13.42.21
+Condition-prepregnancy-diabetes = 2.16.840.1.113883.4.642.40.13.42.22
+Condition-prepregnancy-hypertension = 2.16.840.1.113883.4.642.40.13.42.23
+Condition-ruptured-uterus = 2.16.840.1.113883.4.642.40.13.42.24
+Condition-seizure = 2.16.840.1.113883.4.642.40.13.42.25
+Coverage-principal-payer-delivery = 2.16.840.1.113883.4.642.40.13.42.26
+Encounter-birth = 2.16.840.1.113883.4.642.40.13.42.27
+Encounter-maternity = 2.16.840.1.113883.4.642.40.13.42.28
+Extension-encounter-maternity-reference = 2.16.840.1.113883.4.642.40.13.42.29
+Extension-jurisdictional-facility-identifier = 2.16.840.1.113883.4.642.40.13.42.30
+Extension-role = 2.16.840.1.113883.4.642.40.13.42.31
+Location-bfdr = 2.16.840.1.113883.4.642.40.13.42.32
+Observation-antibiotics-administered-during-labor = 2.16.840.1.113883.4.642.40.13.42.33
+Observation-apgar-score = 2.16.840.1.113883.4.642.40.13.42.34
+Observation-autopsy-histological-exam-results-used = 2.16.840.1.113883.4.642.40.13.42.35
+Observation-autopsy-performed-indicator = 2.16.840.1.113883.4.642.40.13.42.36
+Observation-birth-plurality-of-pregnancy = 2.16.840.1.113883.4.642.40.13.42.37
+Observation-birth-weight = 2.16.840.1.113883.4.642.40.13.42.38
+Observation-cigarette-smoking-before-during-pregnancy = 2.16.840.1.113883.4.642.40.13.42.39
+Observation-coded-initiating-fetal-death-cause-or-condition = 2.16.840.1.113883.4.642.40.13.42.40
+Observation-coded-other-fetal-death-cause-or-condition = 2.16.840.1.113883.4.642.40.13.42.41
+Observation-date-of-first-prenatal-care-visit = 2.16.840.1.113883.4.642.40.13.42.42
+Observation-date-of-last-live-birth = 2.16.840.1.113883.4.642.40.13.42.43
+Observation-date-of-last-other-pregnancy-outcome = 2.16.840.1.113883.4.642.40.13.42.44
+Observation-fetal-death-time-point = 2.16.840.1.113883.4.642.40.13.42.45
+Observation-fetal-presentation = 2.16.840.1.113883.4.642.40.13.42.46
+Observation-fetal-remains-disposition-method = 2.16.840.1.113883.4.642.40.13.42.47
+Observation-gestational-age-at-delivery = 2.16.840.1.113883.4.642.40.13.42.48
+Observation-histological-placental-exam-performed = 2.16.840.1.113883.4.642.40.13.42.49
+Observation-icu-admission = 2.16.840.1.113883.4.642.40.13.42.50
+Observation-infant-breastfed-at-discharge = 2.16.840.1.113883.4.642.40.13.42.51
+Observation-infant-living = 2.16.840.1.113883.4.642.40.13.42.52
+Observation-labor-trial-attempted = 2.16.840.1.113883.4.642.40.13.42.53
+Observation-last-menstrual-period = 2.16.840.1.113883.4.642.40.13.42.54
+Observation-mother-delivery-weight = 2.16.840.1.113883.4.642.40.13.42.55
+Observation-mother-height = 2.16.840.1.113883.4.642.40.13.42.56
+Observation-mother-married-during-pregnancy = 2.16.840.1.113883.4.642.40.13.42.57
+Observation-mother-prepregnancy-weight = 2.16.840.1.113883.4.642.40.13.42.58
+Observation-mother-received-wic-food = 2.16.840.1.113883.4.642.40.13.42.59
+Observation-nicu-admission = 2.16.840.1.113883.4.642.40.13.42.60
+Observation-no-infections-present-during-pregnancy = 2.16.840.1.113883.4.642.40.13.42.61
+Observation-none-congenital-anomolies-of-the-newborn = 2.16.840.1.113883.4.642.40.13.42.62
+Observation-none-of-specified-abnormal-conditions-of-newborn = 2.16.840.1.113883.4.642.40.13.42.63
+Observation-none-of-specified-characteristics-labor-delivery = 2.16.840.1.113883.4.642.40.13.42.64
+Observation-none-of-specified-maternal-morbidities = 2.16.840.1.113883.4.642.40.13.42.65
+Observation-none-of-specified-obstetric-procedures = 2.16.840.1.113883.4.642.40.13.42.66
+Observation-none-of-specified-pregnancy-risk-factors = 2.16.840.1.113883.4.642.40.13.42.67
+Observation-number-births-now-dead = 2.16.840.1.113883.4.642.40.13.42.68
+Observation-number-births-now-living = 2.16.840.1.113883.4.642.40.13.42.69
+Observation-number-fetal-deaths-this-delivery = 2.16.840.1.113883.4.642.40.13.42.70
+Observation-number-live-births-this-delivery = 2.16.840.1.113883.4.642.40.13.42.71
+Observation-number-other-pregnancy-outcomes = 2.16.840.1.113883.4.642.40.13.42.72
+Observation-number-prenatal-visits = 2.16.840.1.113883.4.642.40.13.42.73
+Observation-number-previous-cesareans = 2.16.840.1.113883.4.642.40.13.42.74
+Observation-paternity-acknowledgement-signed = 2.16.840.1.113883.4.642.40.13.42.75
+Observation-planned-to-deliver-at-home = 2.16.840.1.113883.4.642.40.13.42.76
+Observation-present-job = 2.16.840.1.113883.4.642.40.13.42.77
+Observation-previous-cesarean = 2.16.840.1.113883.4.642.40.13.42.78
+Observation-previous-preterm-birth = 2.16.840.1.113883.4.642.40.13.42.79
+Observation-ssn-requested-for-child = 2.16.840.1.113883.4.642.40.13.42.80
+Observation-steroids-fetal-lung-maturation = 2.16.840.1.113883.4.642.40.13.42.81
+Observation-unknown-final-route-and-method-of-delivery = 2.16.840.1.113883.4.642.40.13.42.82
+Patient-decedent-fetus = 2.16.840.1.113883.4.642.40.13.42.83
+Practitioner-birth-attendant = 2.16.840.1.113883.4.642.40.13.42.84
+Practitioner-birth-certifier = 2.16.840.1.113883.4.642.40.13.42.85
+Procedure-antibiotic-suspected-neonatal-sepsis = 2.16.840.1.113883.4.642.40.13.42.86
+Procedure-assisted-reproductive-technology = 2.16.840.1.113883.4.642.40.13.42.87
+Procedure-assisted-ventilation-following-delivery = 2.16.840.1.113883.4.642.40.13.42.88
+Procedure-assisted-ventilation-more-than-six-hours = 2.16.840.1.113883.4.642.40.13.42.89
+Procedure-augmentation-of-labor = 2.16.840.1.113883.4.642.40.13.42.90
+Procedure-blood-transfusion = 2.16.840.1.113883.4.642.40.13.42.91
+Procedure-epidural-or-spinal-anesthesia = 2.16.840.1.113883.4.642.40.13.42.92
+Procedure-fertility-enhancing-drug-therapy-artificial-insem = 2.16.840.1.113883.4.642.40.13.42.93
+Procedure-final-route-method-delivery = 2.16.840.1.113883.4.642.40.13.42.94
+Procedure-induction-of-labor = 2.16.840.1.113883.4.642.40.13.42.95
+Procedure-infertility-treatment = 2.16.840.1.113883.4.642.40.13.42.96
+Procedure-obstetric = 2.16.840.1.113883.4.642.40.13.42.97
+Procedure-surfactant-replacement-therapy = 2.16.840.1.113883.4.642.40.13.42.98
+Procedure-unplanned-hysterectomy = 2.16.840.1.113883.4.642.40.13.42.99
+practitioner-role-birth-attendant = 2.16.840.1.113883.4.642.40.13.42.100
+practitioner-role-birth-certifier = 2.16.840.1.113883.4.642.40.13.42.101
+
+[CapabilityStatement]
+CapabilityStatement-bfdr = 2.16.840.1.113883.4.642.40.13.13.1
+
+[Questionnaire]
+Questionnaire-mothers-live-birth = 2.16.840.1.113883.4.642.40.13.35.1
+Questionnaire-patients-fetal-death = 2.16.840.1.113883.4.642.40.13.35.2
+


### PR DESCRIPTION
Git mentions 2 files were changed, including oids.ini. oids.ini was updated when publisher was ran. Only manual change applied was relaxing cardinality on subject for composition, based on JIRA ticket: https://jira.hl7.org/browse/FHIR-49904